### PR TITLE
Add token scope information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-Here's a little repo to allow you to fork all U.S. government repos, just in case the originals disappear in the next few years.
+Here's a little repo to allow you to fork all U.S. government repos, just in
+case the originals disappear in the next few years.
 
-If you have a git username and oauth key, you can fork the repos yourself. Running this script will create ~1670 new repositories in your account, so you may want to create a special account just for this. You will need a [new token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for the new account. Be sure to copy the new key when you create it, as Github will not show it to you again.
+If you have a github username and oauth key, you can fork the repos yourself.
+Running this script will create ~1670 new repositories in your account, so you
+may want to create a special account just for this. You will need a
+[new token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/)
+for the new account. When creating your token, be sure to add the
+`repo:public_repo` scope, and be sure to copy it once created, as Github will
+not show it to you again.
 
 To fork all of the repos:
 
@@ -18,9 +25,11 @@ export GH_OAUTH_KEY='Your OAUTH Key Here'
 php run.php update
 ```
 
-(Obviously you can use also some other mechanism to set the relevant environment variables.)
+(Obviously you can use also some other mechanism to set the relevant environment
+variables.)
 
-Note that this looks only for master branches upstream. If one doesn't exist, then the exception is caught and logged to STDOUT.
+Note that this looks only for master branches upstream. If one doesn't exist,
+then the exception is caught and logged to STDOUT.
 
 TODOs:
 * Tests


### PR DESCRIPTION
Updating the README to indicate which scope is required when creating the oauth token. I also wrapped the README at 80 characters, but happy to revert that change if you prefer.

PS - I ran this script for @klingerf2, and it totally worked! 🎉 